### PR TITLE
back end config changes, but commented out

### DIFF
--- a/MusicMerge/DBConfig.cs
+++ b/MusicMerge/DBConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace MusicMerge
+{
+    internal class DBConfig
+    {
+        public string Angular { get; set; }
+    }
+}

--- a/MusicMerge/Data/MusicMergeContext.cs
+++ b/MusicMerge/Data/MusicMergeContext.cs
@@ -7,17 +7,23 @@ using MusicMerge;
 
 namespace MusicMerge.Data
 {
-    public class MusicMergeContext : DbContext
+    public class MusicMergeContext : DbContext/*, IMusicMergeContext*/
     {
         public MusicMergeContext (DbContextOptions<MusicMergeContext> options)
             : base(options)
         {
         }
+        //private readonly string _connectionString;
 
         public DbSet<MusicMerge.Album> Albums { get; set; }
 
         public DbSet<MusicMerge.GeneratedImage> GeneratedImages { get; set; }
 
         public DbSet<MusicMerge.User> Users { get; set; }
+
+        //public MusicMergeContext(IOptions<DBConfig> dbConfig)
+        //{
+        //    _connectionString = dbConfig.Value.Angular;
+        //}
     }
 }

--- a/MusicMerge/Startup.cs
+++ b/MusicMerge/Startup.cs
@@ -27,6 +27,7 @@ namespace MusicMerge
         public void ConfigureServices(IServiceCollection services)
         {
 
+            services.Configure<DBConfig>(Configuration.GetSection("ConnectionString"));
             services.AddControllers();
             services.AddSwaggerGen(c =>
             {


### PR DESCRIPTION
So I worked in the solution I found doing back to front end angular in the last project. added the DB config class and db config to the connection string for angular. I commented out all the changes i actually made in VS so it doesnt break anything once pulled down, but i think we might need to add an IMusicMergeConext to make it work. let me know what you think. copying changes below so you know what to look for: 
- added DB config class with angular property
- in startup added, services.Configure<DBConfig>(Configuration.GetSection("ConnectionString"));
-         //public MusicMergeContext(IOptions<DBConfig> dbConfig)
        //{
        //    _connectionString = dbConfig.Value.Angular;
        //} 
        
      /*, IMusicMergeContext*/
     //private readonly string _connectionString;
   ------ added to musicmergecontext 
